### PR TITLE
Release/v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @strata-foundation/strata
 
-
-
-## [Unreleased]
-
-
-## [1.3.3]
-
 ### Fixed
 
  * usePriceInSol broken for wrappedSolMint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-
-
 ## [Unreleased]
+
+
+## [1.3.3]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.3](https://github.com/StrataFoundation/strata/compare/v1.3.2...v1.3.3) (2021-12-22)
+
+**Note:** Version bump only for package @strata-foundation/strata
+
+
+
+
+
 ## [Unreleased]
 
 ### Fixed

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "1.3.2"
+  "version": "1.3.3"
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.3](https://github.com/StrataFoundation/strata/compare/v1.3.2...v1.3.3) (2021-12-22)
+
+**Note:** Version bump only for package @strata-foundation/cli
+
+
+
+
+
 ## [1.3.2](https://github.com/StrataFoundation/strata/compare/v0.7.0...v1.3.2) (2021-12-15)
 
 **Note:** Version bump only for package @strata-foundation/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,8 +21,8 @@
     "dependencies": {
         "@project-serum/common": "^0.0.1-beta.3",
         "@solana/web3.js": "^1.29.2",
-        "@strata-foundation/spl-token-bonding": "^1.3.2",
-        "@strata-foundation/spl-token-collective": "^1.3.2",
+        "@strata-foundation/spl-token-bonding": "^1.3.3",
+        "@strata-foundation/spl-token-collective": "^1.3.3",
         "@strata-foundation/spl-token-staking": "^1.3.2",
         "@strata-foundation/spl-utils": "^1.3.2",
         "bn.js": "^5.2.0",
@@ -35,5 +35,5 @@
         "typescript": "^4.3.4"
     },
     "gitHead": "9a64fbd7484a63f4e039008a2494573e8bf99229",
-    "version": "1.3.2"
+    "version": "1.3.3"
 }

--- a/packages/docs/CHANGELOG.md
+++ b/packages/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.3](https://github.com/StrataFoundation/strata/compare/v1.3.2...v1.3.3) (2021-12-22)
+
+**Note:** Version bump only for package docs
+
+
+
+
+
 ## [1.3.2](https://github.com/ChewingGlassFund/wumbo-programs/compare/v0.7.0...v1.3.2) (2021-12-15)
 
 **Note:** Version bump only for package docs

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -29,9 +29,9 @@
     "@solana/wallet-adapter-react-ui": "^0.6.0",
     "@solana/wallet-adapter-wallets": "^0.11.1",
     "@solana/web3.js": "^1.29.2",
-    "@strata-foundation/react": "^1.3.2",
-    "@strata-foundation/spl-token-bonding": "^1.3.2",
-    "@strata-foundation/spl-token-collective": "^1.3.2",
+    "@strata-foundation/react": "^1.3.3",
+    "@strata-foundation/spl-token-bonding": "^1.3.3",
+    "@strata-foundation/spl-token-collective": "^1.3.3",
     "@svgr/webpack": "^5.5.0",
     "assert": "^2.0.0",
     "browserify-zlib": "^0.2.0",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.3](https://github.com/StrataFoundation/strata/compare/v1.3.2...v1.3.3) (2021-12-22)
+
+**Note:** Version bump only for package @strata-foundation/react
+
+
+
+
+
 ## [1.3.2](https://github.com/ChewingGlassFund/wumbo-programs/compare/v0.7.0...v1.3.2) (2021-12-15)
 
 **Note:** Version bump only for package @strata-foundation/react

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strata-foundation/react",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "React utils for strata foundation",
   "source": "src/index.ts",
   "main": "dist/lib/index.js",
@@ -31,8 +31,8 @@
     "@solana/wallet-adapter-react-ui": "^0.6.0",
     "@solana/wallet-adapter-wallets": "^0.11.1",
     "@solana/web3.js": "^1.29.2",
-    "@strata-foundation/spl-token-bonding": "^1.3.2",
-    "@strata-foundation/spl-token-collective": "^1.3.2",
+    "@strata-foundation/spl-token-bonding": "^1.3.3",
+    "@strata-foundation/spl-token-collective": "^1.3.3",
     "@strata-foundation/spl-utils": "^1.3.2",
     "buffer": "^6.0.3",
     "dotenv": "^10.0.0",

--- a/packages/spl-token-bonding/CHANGELOG.md
+++ b/packages/spl-token-bonding/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.3](https://github.com/StrataFoundation/strata/compare/v1.3.2...v1.3.3) (2021-12-22)
+
+**Note:** Version bump only for package @strata-foundation/spl-token-bonding
+
+
+
+
+
 ## [1.3.2](https://github.com/StrataFoundation/strata/compare/v0.7.0...v1.3.2) (2021-12-15)
 
 **Note:** Version bump only for package @strata-foundation/spl-token-bonding

--- a/packages/spl-token-bonding/package.json
+++ b/packages/spl-token-bonding/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Interface to the spl-token-bonding smart contract",
   "repository": {
     "type": "git",

--- a/packages/spl-token-collective/CHANGELOG.md
+++ b/packages/spl-token-collective/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.3](https://github.com/StrataFoundation/strata/compare/v1.3.2...v1.3.3) (2021-12-22)
+
+**Note:** Version bump only for package @strata-foundation/spl-token-collective
+
+
+
+
+
 ## [1.3.2](https://github.com/StrataFoundation/strata/compare/v0.7.0...v1.3.2) (2021-12-15)
 
 **Note:** Version bump only for package @strata-foundation/spl-token-collective

--- a/packages/spl-token-collective/package.json
+++ b/packages/spl-token-collective/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strata-foundation/spl-token-collective",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Interface to the spl-token-collective smart contract",
   "publishConfig": {
     "access": "public",
@@ -30,7 +30,7 @@
     "@project-serum/anchor": "^0.18.0",
     "@project-serum/common": "^0.0.1-beta.3",
     "@solana/web3.js": "^1.29.2",
-    "@strata-foundation/spl-token-bonding": "^1.3.2",
+    "@strata-foundation/spl-token-bonding": "^1.3.3",
     "@strata-foundation/spl-token-staking": "^1.3.2",
     "@strata-foundation/spl-utils": "^1.3.2",
     "bn.js": "^5.2.0",


### PR DESCRIPTION
### Fixed
- usePriceInSol broken for wrappedSolMint
- Use wrappedSolMint from token bonding state instead of global variable, as it is different for every environment. It's too late to fix this as there's already a wrapped sol in prod.
- baseMint would not show up in swap interface after changing the base once because of a useMemo
### Added
- unixTime to pricing so we can price the curve at a given point in time