### PR TITLE
Release/v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [2.0.4](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.0.3-test...v2.0.4) (2021-12-29)
 
-**Note:** Version bump only for package @strata-foundation/strata
-
-
-
-
-
-## [Unreleased]
-
 ### Added
 
   * Ability to add transition fees to piecewise time curves, making for a less bottable fair launch.
@@ -20,6 +12,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Changed
 
  * Max pow or frac on exponential curves to 10. Any more than that risks blowing compute.
+
+### Fixed
+
+ * `targetMintDecimals: 0` no longer throws an error.
 
 ## [2.0.3](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.0.2...v2.0.3) (2021-12-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.0.3-test...v2.0.4) (2021-12-29)
+
+**Note:** Version bump only for package @strata-foundation/strata
+
+
+
+
+
 ## [Unreleased]
 
 ### Added

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.0.3"
+  "version": "2.0.4"
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/StrataFoundation/strata/compare/v2.0.3-test...v2.0.4) (2021-12-29)
+
+**Note:** Version bump only for package @strata-foundation/cli
+
+
+
+
+
 ## [2.0.3](https://github.com/StrataFoundation/strata/compare/v2.0.2...v2.0.3) (2021-12-24)
 
 **Note:** Version bump only for package @strata-foundation/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,9 +22,9 @@
     "dependencies": {
         "@project-serum/common": "^0.0.1-beta.3",
         "@solana/web3.js": "^1.29.2",
-        "@strata-foundation/spl-token-bonding": "^2.0.0",
-        "@strata-foundation/spl-token-collective": "^2.0.1",
-        "@strata-foundation/spl-token-staking": "^2.0.0",
+        "@strata-foundation/spl-token-bonding": "^2.0.4",
+        "@strata-foundation/spl-token-collective": "^2.0.4",
+        "@strata-foundation/spl-token-staking": "^2.0.4",
         "@strata-foundation/spl-utils": "^2.0.0",
         "bn.js": "^5.2.0",
         "copyfiles": "^2.4.1",
@@ -36,5 +36,5 @@
         "typescript": "^4.3.4"
     },
     "gitHead": "9a64fbd7484a63f4e039008a2494573e8bf99229",
-    "version": "2.0.3"
+    "version": "2.0.4"
 }

--- a/packages/docs/CHANGELOG.md
+++ b/packages/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.0.3-test...v2.0.4) (2021-12-29)
+
+**Note:** Version bump only for package docs
+
+
+
+
+
 # [2.0.0](https://github.com/ChewingGlassFund/wumbo-programs/compare/v1.3.2...v2.0.0) (2021-12-24)
 
 **Note:** Version bump only for package docs

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -29,9 +29,9 @@
     "@solana/wallet-adapter-react-ui": "^0.6.0",
     "@solana/wallet-adapter-wallets": "^0.11.1",
     "@solana/web3.js": "^1.29.2",
-    "@strata-foundation/react": "^2.0.1",
-    "@strata-foundation/spl-token-bonding": "^2.0.0",
-    "@strata-foundation/spl-token-collective": "^2.0.1",
+    "@strata-foundation/react": "^2.0.4",
+    "@strata-foundation/spl-token-bonding": "^2.0.4",
+    "@strata-foundation/spl-token-collective": "^2.0.4",
     "@svgr/webpack": "^5.5.0",
     "assert": "^2.0.0",
     "browserify-zlib": "^0.2.0",

--- a/packages/governance-cli/CHANGELOG.md
+++ b/packages/governance-cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.0.3-test...v2.0.4) (2021-12-29)
+
+**Note:** Version bump only for package @strata-foundation/governance-cli
+
+
+
+
+
 # [2.0.0](https://github.com/ChewingGlassFund/wumbo-programs/compare/v1.3.2...v2.0.0) (2021-12-24)
 
 **Note:** Version bump only for package @strata-foundation/governance-cli

--- a/packages/governance-cli/package.json
+++ b/packages/governance-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strata-foundation/governance-cli",
-  "version": "2.0.0",
+  "version": "2.0.4",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.0.3-test...v2.0.4) (2021-12-29)
+
+**Note:** Version bump only for package @strata-foundation/react
+
+
+
+
+
 # [2.0.0](https://github.com/ChewingGlassFund/wumbo-programs/compare/v1.3.2...v2.0.0) (2021-12-24)
 
 **Note:** Version bump only for package @strata-foundation/react

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strata-foundation/react",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "description": "React utils for strata foundation",
   "source": "src/index.ts",
   "main": "dist/lib/index.js",
@@ -31,8 +31,8 @@
     "@solana/wallet-adapter-react-ui": "^0.6.0",
     "@solana/wallet-adapter-wallets": "^0.11.1",
     "@solana/web3.js": "^1.29.2",
-    "@strata-foundation/spl-token-bonding": "^2.0.0",
-    "@strata-foundation/spl-token-collective": "^2.0.1",
+    "@strata-foundation/spl-token-bonding": "^2.0.4",
+    "@strata-foundation/spl-token-collective": "^2.0.4",
     "@strata-foundation/spl-utils": "^2.0.0",
     "buffer": "^6.0.3",
     "dotenv": "^10.0.0",

--- a/packages/spl-token-bonding/CHANGELOG.md
+++ b/packages/spl-token-bonding/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/StrataFoundation/strata/compare/v2.0.3-test...v2.0.4) (2021-12-29)
+
+**Note:** Version bump only for package @strata-foundation/spl-token-bonding
+
+
+
+
+
 # [2.0.0](https://github.com/StrataFoundation/strata/compare/v1.3.2...v2.0.0) (2021-12-24)
 
 **Note:** Version bump only for package @strata-foundation/spl-token-bonding

--- a/packages/spl-token-bonding/package.json
+++ b/packages/spl-token-bonding/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "2.0.0",
+  "version": "2.0.4",
   "description": "Interface to the spl-token-bonding smart contract",
   "repository": {
     "type": "git",

--- a/packages/spl-token-collective/CHANGELOG.md
+++ b/packages/spl-token-collective/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/StrataFoundation/strata/compare/v2.0.3-test...v2.0.4) (2021-12-29)
+
+**Note:** Version bump only for package @strata-foundation/spl-token-collective
+
+
+
+
+
 # [2.0.0](https://github.com/StrataFoundation/strata/compare/v1.3.2...v2.0.0) (2021-12-24)
 
 **Note:** Version bump only for package @strata-foundation/spl-token-collective

--- a/packages/spl-token-collective/package.json
+++ b/packages/spl-token-collective/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strata-foundation/spl-token-collective",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "description": "Interface to the spl-token-collective smart contract",
   "publishConfig": {
     "access": "public",
@@ -30,8 +30,8 @@
     "@project-serum/anchor": "^0.18.0",
     "@project-serum/common": "^0.0.1-beta.3",
     "@solana/web3.js": "^1.29.2",
-    "@strata-foundation/spl-token-bonding": "^2.0.0",
-    "@strata-foundation/spl-token-staking": "^2.0.0",
+    "@strata-foundation/spl-token-bonding": "^2.0.4",
+    "@strata-foundation/spl-token-staking": "^2.0.4",
     "@strata-foundation/spl-utils": "^2.0.0",
     "bn.js": "^5.2.0",
     "copyfiles": "^2.4.1"

--- a/packages/spl-token-staking/CHANGELOG.md
+++ b/packages/spl-token-staking/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/StrataFoundation/wumbo/compare/v2.0.3-test...v2.0.4) (2021-12-29)
+
+**Note:** Version bump only for package @strata-foundation/spl-token-staking
+
+
+
+
+
 # [2.0.0](https://github.com/StrataFoundation/wumbo/compare/v1.3.2...v2.0.0) (2021-12-24)
 
 **Note:** Version bump only for package @strata-foundation/spl-token-staking

--- a/packages/spl-token-staking/package.json
+++ b/packages/spl-token-staking/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@strata-foundation/spl-token-staking",
-    "version": "2.0.0",
+    "version": "2.0.4",
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION

### Added

  * Ability to add transition fees to piecewise time curves, making for a less bottable fair launch.

### Changed

 * Max pow or frac on exponential curves to 10. Any more than that risks blowing compute.

### Fixed

 * `targetMintDecimals: 0` no longer throws an error.