### PR TITLE
drop version for fees

### DIFF
--- a/packages/spl-utils/package.json
+++ b/packages/spl-utils/package.json
@@ -25,7 +25,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "@metaplex/arweave-cost": "^2.0.0",
+    "@metaplex/arweave-cost": "^1.0.4",
     "@metaplex/js": "^4.3.0",
     "@solana/spl-name-service": "^0.1.3",
     "@solana/web3.js": "^1.30.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3333,10 +3333,10 @@
   resolved "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.22.tgz"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
-"@metaplex/arweave-cost@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@metaplex/arweave-cost/-/arweave-cost-2.0.0.tgz#74d4dbb5b39e89f81fbc1a50220d1837fe0efdfd"
-  integrity sha512-i2FTLtg7Zz9sVJxKHlr3Ek1ibcG4l/we3r5ZQYlCtNFforBj+w6OnyGwdqSaFIkxSyYXqAlo9BY7cc/WEuTccA==
+"@metaplex/arweave-cost@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@metaplex/arweave-cost/-/arweave-cost-1.0.4.tgz#35d5d10dfc855463fc7fe18594e175506a4a35d4"
+  integrity sha512-bJ7knj9bacarfoIgkomDUOIRURYBAIYUg1oJZh1MfAl9w28x1gfMkt2e7H5zK0HDKkS2lmJQ5dpcsR+FGP9zMA==
   dependencies:
     axios "^0.24.0"
     debug "^4.3.2"


### PR DESCRIPTION
Arweave upload was resulting in
![unknown](https://user-images.githubusercontent.com/694011/149561092-4f52d03b-5c73-478d-bfe8-7e6fd2d65c44.png)
After looking at metaplex noticed they were on  `"@metaplex/arweave-cost": "^1.0.4"` deprecating our version seems to have solved it.

(2.0.0, 1.0.4)
<img width="1263" alt="Screen Shot 2022-01-14 at 11 19 38 AM" src="https://user-images.githubusercontent.com/694011/149561293-fb529625-af5f-4926-8943-0b4400ee9732.png">

