### PR TITLE
chore(release): publish 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.2...v2.1.3) (2022-01-18)
+
+Temporary endpoint to upgrade social token curves
+
 ## [2.1.2](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.1...v2.1.2) (2022-01-17)
 
 Downgrade @metaplex/arweave-cost since 2.x.x results in errors

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.1.2"
+  "version": "2.1.3"
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/StrataFoundation/strata/compare/v2.1.2...v2.1.3) (2022-01-18)
+
+**Note:** Version bump only for package @strata-foundation/cli
+
+
+
+
+
 ## [2.1.2](https://github.com/StrataFoundation/strata/compare/v2.1.1...v2.1.2) (2022-01-17)
 
 **Note:** Version bump only for package @strata-foundation/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,8 +22,8 @@
     "dependencies": {
         "@project-serum/common": "^0.0.1-beta.3",
         "@solana/web3.js": "^1.29.2",
-        "@strata-foundation/spl-token-bonding": "^2.1.2",
-        "@strata-foundation/spl-token-collective": "^2.1.2",
+        "@strata-foundation/spl-token-bonding": "^2.1.3",
+        "@strata-foundation/spl-token-collective": "^2.1.3",
         "@strata-foundation/spl-token-staking": "^2.1.2",
         "@strata-foundation/spl-utils": "^2.1.2",
         "bn.js": "^5.2.0",
@@ -36,5 +36,5 @@
         "typescript": "^4.3.4"
     },
     "gitHead": "9a64fbd7484a63f4e039008a2494573e8bf99229",
-    "version": "2.1.2"
+    "version": "2.1.3"
 }

--- a/packages/docs/CHANGELOG.md
+++ b/packages/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.2...v2.1.3) (2022-01-18)
+
+**Note:** Version bump only for package docs
+
+
+
+
+
 ## [2.1.2](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.1...v2.1.2) (2022-01-17)
 
 **Note:** Version bump only for package docs

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -29,9 +29,9 @@
     "@solana/wallet-adapter-react-ui": "0.9.2",
     "@solana/wallet-adapter-wallets": "0.14.0",
     "@solana/web3.js": "^1.29.2",
-    "@strata-foundation/react": "^2.1.2",
-    "@strata-foundation/spl-token-bonding": "^2.1.2",
-    "@strata-foundation/spl-token-collective": "^2.1.2",
+    "@strata-foundation/react": "^2.1.3",
+    "@strata-foundation/spl-token-bonding": "^2.1.3",
+    "@strata-foundation/spl-token-collective": "^2.1.3",
     "@svgr/webpack": "^5.5.0",
     "assert": "^2.0.0",
     "browserify-zlib": "^0.2.0",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.2...v2.1.3) (2022-01-18)
+
+**Note:** Version bump only for package @strata-foundation/react
+
+
+
+
+
 ## [2.1.2](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.1...v2.1.2) (2022-01-17)
 
 **Note:** Version bump only for package @strata-foundation/react

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strata-foundation/react",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "React utils for strata foundation",
   "source": "src/index.ts",
   "main": "dist/lib/index.js",
@@ -31,8 +31,8 @@
     "@solana/wallet-adapter-react": "0.15.1",
     "@solana/wallet-adapter-wallets": "0.14.0",
     "@solana/web3.js": "^1.29.2",
-    "@strata-foundation/spl-token-bonding": "^2.1.2",
-    "@strata-foundation/spl-token-collective": "^2.1.2",
+    "@strata-foundation/spl-token-bonding": "^2.1.3",
+    "@strata-foundation/spl-token-collective": "^2.1.3",
     "@strata-foundation/spl-utils": "^2.1.2",
     "@toruslabs/solana-embed": "0.0.9",
     "buffer": "^6.0.3",

--- a/packages/spl-token-bonding/CHANGELOG.md
+++ b/packages/spl-token-bonding/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/StrataFoundation/strata/compare/v2.1.2...v2.1.3) (2022-01-18)
+
+**Note:** Version bump only for package @strata-foundation/spl-token-bonding
+
+
+
+
+
 ## [2.1.2](https://github.com/StrataFoundation/strata/compare/v2.1.1...v2.1.2) (2022-01-17)
 
 **Note:** Version bump only for package @strata-foundation/spl-token-bonding

--- a/packages/spl-token-bonding/package.json
+++ b/packages/spl-token-bonding/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Interface to the spl-token-bonding smart contract",
   "repository": {
     "type": "git",

--- a/packages/spl-token-collective/CHANGELOG.md
+++ b/packages/spl-token-collective/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/StrataFoundation/strata/compare/v2.1.2...v2.1.3) (2022-01-18)
+
+**Note:** Version bump only for package @strata-foundation/spl-token-collective
+
+
+
+
+
 ## [2.1.2](https://github.com/StrataFoundation/strata/compare/v2.1.1...v2.1.2) (2022-01-17)
 
 **Note:** Version bump only for package @strata-foundation/spl-token-collective

--- a/packages/spl-token-collective/package.json
+++ b/packages/spl-token-collective/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strata-foundation/spl-token-collective",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Interface to the spl-token-collective smart contract",
   "publishConfig": {
     "access": "public",
@@ -31,7 +31,7 @@
     "@project-serum/anchor": "^0.18.0",
     "@project-serum/common": "^0.0.1-beta.3",
     "@solana/web3.js": "^1.29.2",
-    "@strata-foundation/spl-token-bonding": "^2.1.2",
+    "@strata-foundation/spl-token-bonding": "^2.1.3",
     "@strata-foundation/spl-token-staking": "^2.1.2",
     "@strata-foundation/spl-utils": "^2.1.2",
     "bn.js": "^5.2.0",


### PR DESCRIPTION
## [2.1.3](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.2...v2.1.3) (2022-01-18)

Temporary endpoint to upgrade social token curves