### PR TITLE
chore(release): publish 2.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.9](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.8...v2.1.9) (2022-01-20)
+
+**Note:** Version bump only for package @strata-foundation/strata
+
+Fix for claiming already minted token
+
+
 ## [2.1.8](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.7...v2.1.8) (2022-01-20)
 
 **Note:** Version bump only for package @strata-foundation/strata

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.1.8"
+  "version": "2.1.9"
 }

--- a/packages/docs/CHANGELOG.md
+++ b/packages/docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.9](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.8...v2.1.9) (2022-01-20)
+
+**Note:** Version bump only for package docs
+
+
+
+
+
 ## [2.1.8](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.7...v2.1.8) (2022-01-20)
 
 **Note:** Version bump only for package docs

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## [2.1.9](https://github.com/ChewingGlassFund/wumbo-programs/compare/v2.1.8...v2.1.9) (2022-01-20)

**Note:** Version bump only for package @strata-foundation/strata

Fix for claiming already minted token
