### PR TITLE
fixed link to getting started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 What is strata? Check out our [Hello World](https://blog.strataprotocol.com/welcome)
 
-View the live documentation [here](https://docs.strataprotocol.com/getting_started)
+View the live documentation [here](https://docs.strataprotocol.com)
 
 This series of smart contracts serves to standardizing and indexing all social tokens.
 


### PR DESCRIPTION
The current link to the Getting Started docs results in a 404 -- this PR is a simple fix for that!