### PR TITLE
fix(token-bonding): use toArrayLike for compatibility

### DIFF
--- a/packages/spl-token-bonding/src/index.ts
+++ b/packages/spl-token-bonding/src/index.ts
@@ -846,7 +846,7 @@ export class SplTokenBonding extends AnchorSdk<SplTokenBondingIDL> {
     programId: PublicKey = SplTokenBonding.ID
   ): Promise<[PublicKey, number]> {
     const pad = Buffer.alloc(2);
-    new BN(index, 16, "le").toBuffer().copy(pad);
+    new BN(index, 16, "le").toArrayLike(Buffer).copy(pad);
     return PublicKey.findProgramAddress(
       [Buffer.from("token-bonding", "utf-8"), targetMint!.toBuffer(), pad],
       programId


### PR DESCRIPTION
BN.js errors out as `TypeError: (intermediate value).toBuffer is not a function` when used with bundlers like browserify. As explained in BN.js Readme: https://github.com/indutny/bn.js

`a.toBuffer(endian, length)` - convert to Node.js Buffer (if available). For compatibility with browserify and similar tools, use this instead: `a.toArrayLike(Buffer, endian, length)`

It might be better to use this to enable bundlers without any significant downsides.