### PR TITLE
fix(transactions): remove subscription if available

### DIFF
--- a/packages/marketplace-ui/src/components/lbc/mint/candy-machine.ts
+++ b/packages/marketplace-ui/src/components/lbc/mint/candy-machine.ts
@@ -128,7 +128,7 @@ export const awaitTransactionSignatureConfirmation = async (
   });
 
   //@ts-ignore
-  if (connection._signatureSubscriptions[subId]) {
+  if (connection._signatureSubscriptions && connection._signatureSubscriptions[subId]) {
     connection.removeSignatureListener(subId);
   }
   done = true;

--- a/packages/spl-utils/src/transaction.ts
+++ b/packages/spl-utils/src/transaction.ts
@@ -229,7 +229,7 @@ export const awaitTransactionSignatureConfirmation = async (
   });
 
   //@ts-ignore
-  if (connection._signatureSubscriptions[subId]) {
+  if (connection._signatureSubscriptions && connection._signatureSubscriptions[subId]) {
     connection.removeSignatureListener(subId);
   }
   done = true;


### PR DESCRIPTION
Signature subscriptions are not available when the Connection object is used with a browser bundler. This PR adds a fail-safe for `_signatureSubscriptions` property of `connection` object removing the listener only when the subscriptions property is available.