### PR TITLE
fix transaction errors not displaying in lbc token offering

### DIFF
--- a/packages/marketplace-ui/src/components/Providers.tsx
+++ b/packages/marketplace-ui/src/components/Providers.tsx
@@ -1,7 +1,6 @@
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import {
   Notification,
-  StrataProviders
 } from "@strata-foundation/react";
 import React from "react";
 import toast from "react-hot-toast";
@@ -51,9 +50,7 @@ export const Providers = ({
   return (
     <Wallet cluster={cluster}>
       <WalletModalProvider>
-        <StrataProviders onError={onError} resetCSS>
-          <MarketplaceProviders>{children}</MarketplaceProviders>
-        </StrataProviders>
+        <MarketplaceProviders onError={onError} resetCSS>{children}</MarketplaceProviders>
       </WalletModalProvider>
     </Wallet>
   );


### PR DESCRIPTION
The StrataProviders component was duplicated, since it's also in the MarketplaceProviders component. Errors were being caught by a default handler in the child component and not propagating to the correct error handler.