### PR TITLE
fix(CandyMachine): add setCollectionDuringMint instruction to mintOneToken

### DIFF
--- a/packages/marketplace-ui/src/components/lbc/mint/DynamicPricingCandyMachine.tsx
+++ b/packages/marketplace-ui/src/components/lbc/mint/DynamicPricingCandyMachine.tsx
@@ -66,8 +66,8 @@ export const DynamicPricingCandyMachine = (props: DynamicPricingCandyMachineProp
   const onMint = async (args: IMintArgs) => {
     try {
       document.getElementById("#identity")?.click();
-      if (connected && candyMachine?.program && publicKey) {
-        const mint = await mintOneToken(candyMachine, publicKey, args);
+      if (connected && candyMachine?.program && publicKey && props.candyMachineId)  {
+        const mint = await mintOneToken(props.candyMachineId, candyMachine, publicKey, args);
         toast.custom(
           (t) => (
             <MintedNftNotification

--- a/packages/marketplace-ui/src/components/lbc/mint/DynamicPricingCandyMachine.tsx
+++ b/packages/marketplace-ui/src/components/lbc/mint/DynamicPricingCandyMachine.tsx
@@ -67,7 +67,7 @@ export const DynamicPricingCandyMachine = (props: DynamicPricingCandyMachineProp
     try {
       document.getElementById("#identity")?.click();
       if (connected && candyMachine?.program && publicKey && props.candyMachineId)  {
-        const mint = await mintOneToken(props.candyMachineId, candyMachine, publicKey, args);
+        const mint = await mintOneToken(candyMachine, publicKey, args);
         toast.custom(
           (t) => (
             <MintedNftNotification

--- a/packages/marketplace-ui/src/components/lbc/mint/candy-machine.ts
+++ b/packages/marketplace-ui/src/components/lbc/mint/candy-machine.ts
@@ -196,7 +196,6 @@ export const getCollectionAuthorityRecordPDA = async (
 }
 
 export const mintOneToken = async (
-  candyMachineId: PublicKey,
   candyMachine: ICandyMachine,
   payer: anchor.web3.PublicKey,
   { tokenBondingSdk, tokenBonding, maxPrice }: IMintArgs
@@ -219,7 +218,7 @@ export const mintOneToken = async (
     ? (await getAtaForMint(candyMachine.tokenMint, payer))[0]
     : payer
 
-  const candyMachineAddress = candyMachineId
+  const candyMachineAddress = candyMachine.publicKey
   const remainingAccounts = []
   const instructions = []
   const signers: Signer[] = [mint]

--- a/packages/marketplace-ui/src/hooks/useCandyMachine.tsx
+++ b/packages/marketplace-ui/src/hooks/useCandyMachine.tsx
@@ -17,6 +17,7 @@ export const CANDY_MACHINE_PROGRAM = new PublicKey(
  * Unified token bonding interface wrapping the raw TokenBondingV0
  */
 export interface ICandyMachine {
+  authority: PublicKey;
   publicKey: PublicKey;
   program: Program;
   itemsAvailable: number;
@@ -49,6 +50,7 @@ export interface ICandyMachine {
     uri: string;
     hash: Uint8Array;
   };
+  retainAuthority: boolean
 }
 
 async function getCoder(


### PR DESCRIPTION
Setting the collection during mint operation is now enforced by Metaplex, if setCollectionDuringMint is not used, Metaplex doesn't allow minting. 

This PR adds the setCollectionDuringMint instruction after the mintNft instruction and updates the mint function to be compatible with the latest mintOneToken function version in Metaplex repo (https://github.com/metaplex-foundation/metaplex/blob/e20c14069be57ffa09428dd25a07a5bcf7ef51c4/js/packages/candy-machine-ui/src/candy-machine.ts)